### PR TITLE
TECH Add HTML file name on S3 target folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ s3_android(
   region: ENV['S3_REGION'],                       # Required from user.
 
   apk: 'AppName.apk',                             # Required
-  
+
   path: '/path/to/apk',                           # target path on S3
   html_template_path: '/path/to/template',        # path to HTML template
+  html_file_name: '/path/to/template/on/s3'       # path to HTML on S3
 )
 ```
 

--- a/lib/fastlane/plugin/s3_android/actions/s3_android_action.rb
+++ b/lib/fastlane/plugin/s3_android/actions/s3_android_action.rb
@@ -27,6 +27,7 @@ module Fastlane
         params[:bucket] = config[:bucket]
         params[:region] = config[:region]
         params[:html_template_path] = config[:html_template_path]
+        params[:html_file_name] = config[:html_file_name]
         params[:acl] = config[:acl]
         params[:path] = config[:path]
 
@@ -46,6 +47,7 @@ module Fastlane
         UI.user_error!("No APK file path given, pass using `apk: 'apk path'`") unless apk.to_s.length > 0
 
         html_template_path = params[:html_template_path]
+        html_file_name = params[:html_file_name]
 
         apk_version = self.get_version_from_apk(apk)
 
@@ -62,7 +64,7 @@ module Fastlane
         Actions.lane_context[SharedValues::S3_APK_OUTPUT_PATH] = apk_url
         ENV[SharedValues::S3_APK_OUTPUT_PATH.to_s] = apk_url
 
-        html_file_name = "#{s3_path}index.html"
+        html_file_name ||= "index.html"
 
         # grabs module
         eth = Fastlane::ErbTemplateHelper
@@ -245,6 +247,10 @@ module Fastlane
           FastlaneCore::ConfigItem.new(key: :html_template_path,
                                         env_name: "",
                                         description: "html erb template path",
+                                        optional: true),
+          FastlaneCore::ConfigItem.new(key: :html_file_name,
+                                        env_name: "",
+                                        description: "uploaded html filename",
                                         optional: true),
           FastlaneCore::ConfigItem.new(key: :source,
                                        env_name: "S3_SOURCE",


### PR DESCRIPTION
Add html_file_name params to be able to specify the HTML file name on S3 target path