### PR TITLE
Removed extra space character in apk version name regex.

### DIFF
--- a/lib/fastlane/plugin/s3_android/actions/s3_android.rb
+++ b/lib/fastlane/plugin/s3_android/actions/s3_android.rb
@@ -197,7 +197,7 @@ module Fastlane
         get_version = `#{get_version_cmd}`
 
         # return only the X.Y.Z
-        return get_version.scan(/versionName='(.*)\.(.*)\.(.*)' /).first.join(".")
+        return get_version.scan(/versionName='(.*)\.(.*)\.(.*)'/).first.join(".")
       end
 
       def self.description


### PR DESCRIPTION
The version name is retrieved by parsing the output of `aapt` command, which depends on the android sdk build-tools version. The output of aapt version 27.0.3 and below had an attribute `platformBuildVersionName` after `versionName`, but not anymore in 28.0.0 and above, and thus does not have the space character that separates both attributes. Removing the extra space in the regex will make the script compatible with version 28.0.0 and above.